### PR TITLE
Hide mute channel temporary

### DIFF
--- a/app/screens/channel_info/channel_info.js
+++ b/app/screens/channel_info/channel_info.js
@@ -387,18 +387,20 @@ export default class ChannelInfo extends PureComponent {
                             togglable={true}
                             theme={theme}
                         />
-                        <View style={style.separator}/>
-                        <ChannelInfoRow
-                            action={this.handleMuteChannel}
-                            defaultMessage='Mute channel'
-                            detail={this.state.isMuted}
-                            icon='bell-slash-o'
-                            textId='channel_notifications.muteChannel.settings'
-                            togglable={true}
-                            theme={theme}
-                        />
+                        {/**
+                            <View style={style.separator}/>
+                            <ChannelInfoRow
+                                action={this.handleMuteChannel}
+                                defaultMessage='Mute channel'
+                                detail={this.state.isMuted}
+                                icon='bell-slash-o'
+                                textId='channel_notifications.muteChannel.settings'
+                                togglable={true}
+                                theme={theme}
+                            />
+                            **/
+                        }
                         {
-
                         /**
                          <ChannelInfoRow
                          action={() => true}


### PR DESCRIPTION
Hides the mute channel toggle in the channel info. Will show in 4.9