### PR TITLE
Disable nickname and position field in EditProfile

### DIFF
--- a/app/screens/edit_profile/edit_profile.js
+++ b/app/screens/edit_profile/edit_profile.js
@@ -354,8 +354,7 @@ export default class EditProfile extends PureComponent {
         const {nickname} = this.state;
 
         const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' && config.LdapNicknameAttributeSet === 'true') ||
-            (service === 'saml' && config.SamlNicknameAttributeSet === 'true');
+        const disabled = service === 'ldap' || service === 'saml';
 
         return (
             <EditProfileItem
@@ -379,7 +378,7 @@ export default class EditProfile extends PureComponent {
         const {position} = this.state;
 
         const {auth_service: service} = currentUser;
-        const disabled = (service === 'ldap' || service === 'saml') && config.PositionAttribute === 'true';
+        const disabled = (service === 'ldap' || service === 'saml');
 
         return (
             <EditProfileItem
@@ -414,6 +413,8 @@ export default class EditProfile extends PureComponent {
             updating,
         } = this.state;
 
+        const {auth_service: service} = currentUser;
+
         const style = getStyleSheet(theme);
         const uri = profileImage ? profileImage.uri : null;
 
@@ -438,6 +439,16 @@ export default class EditProfile extends PureComponent {
                     </View>
                 </View>
             );
+        }
+
+        let nickname = null;
+        if (service !== 'ldap' && service !== 'saml') {
+            nickname = (
+                <View>
+                    <View style={style.separator}/>
+                    {this.renderNicknameSettings()}
+                </View>
+            )
         }
 
         return (
@@ -475,8 +486,7 @@ export default class EditProfile extends PureComponent {
                         {this.renderUsernameSettings()}
                         <View style={style.separator}/>
                         {this.renderEmailSettings()}
-                        <View style={style.separator}/>
-                        {this.renderNicknameSettings()}
+                        {nickname}
                         <View style={style.separator}/>
                         {this.renderPositionSettings()}
                         <View style={style.footer}/>


### PR DESCRIPTION
To keep parity with desktop settings. I removed the nickname field.
As for the position field it's now disabled.

#### Screenshots

### Android
![screenshot_1525801393](https://user-images.githubusercontent.com/6182543/39773477-40339a12-52c6-11e8-85dd-6d42e58a376b.png)

### iOS
![simulator screen shot - iphone 6 - 2018-05-08 at 13 57 40](https://user-images.githubusercontent.com/6182543/39774067-d1e07efc-52c7-11e8-8e4c-fde5bd3f01f7.png)


