### PR TITLE
Temporarily disable RN Unbundling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ post-install:
 start: | pre-run ## Starts the React Native packager server
 	@if [ $(shell ps -e | grep -i "cli.js start" | grep -civ grep) -eq 0 ]; then \
 		echo Starting React Native packager server; \
-		node ./node_modules/react-native/local-cli/cli.js start --config ../../../../packager/config.js; \
+		node ./node_modules/react-native/local-cli/cli.js start \
 	else \
 		echo React Native packager server already running; \
 	fi

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -73,9 +73,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js",
-    bundleCommand: "unbundle",
-    bundleConfig: "packager/config.js"
+    entryFile: "index.js"
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
Avoids crashes related to the RN Unbundling not working properly in RN 54.